### PR TITLE
Fix split method

### DIFF
--- a/tensordict/tensordict.py
+++ b/tensordict/tensordict.py
@@ -1593,7 +1593,11 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
         dictionaries = [{} for _ in range(len(batch_sizes))]
         update = []
         for key in _TensorDictKeysView(
-            self, include_nested=True, error_on_loop=False, yield_autonested_keys=True
+            self,
+            include_nested=True,
+            leaves_only=False,
+            error_on_loop=False,
+            yield_autonested_keys=True,
         ):
             if isinstance(key, _NestedKey):
                 update.append(key)


### PR DESCRIPTION
## Description

Fix `split` method by adding `_dict_set_nested` which allows to set nested keys in a dictionary, and also by enabling `_TensorDictKeysView` to yield information about nested keys in order that we can restore auto-nesting after the splits have been created.